### PR TITLE
add doi to spec.yaml

### DIFF
--- a/metadata/spec.yaml
+++ b/metadata/spec.yaml
@@ -10,6 +10,14 @@
   format:       last name of first author, year, and letter if necessary
   example:      smith2015a
   required:     yes
+  
+- field:        doi
+  description:  digital object identifier of the study
+  type:         string
+  format:       doi-format
+  example:      10.1002/0470841559.ch1
+  nullable:     yes
+  required:     yes
 
 - field:        long_cite
   description:  long citation


### PR DESCRIPTION
Adds `doi` as a field for all the datasets. This only made one dataset ("Categorization bias") fail validation, which should be simple to fix as the field is set as nullable. 

In the future, it might be nice to add validation but that requires a clear format (i.e. with or without "doi.org").  